### PR TITLE
ENH: Require cmake minimum version to be 3.9.5.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(TBBImageToImageFilter)
 file(READ README.md DOCUMENTATION)
 
 if(NOT ITK_SOURCE_DIR)
-    cmake_minimum_required(VERSION 2.8.9 FATAL_ERROR)
+    cmake_minimum_required(VERSION 3.9.5 FATAL_ERROR)
     find_package(ITK REQUIRED)
     list(APPEND CMAKE_MODULE_PATH ${ITK_CMAKE_DIR})
     include(itk-module-init.cmake)


### PR DESCRIPTION
Require CMake minimum version to be 3.9.5 following ITKv5 requiring
C++11:
https://discourse.itk.org/t/minimum-cmake-version-update/585