### PR TITLE
COMP: Move ITK_DISALLOW_COPY_AND_ASSIGN calls to public section.

### DIFF
--- a/include/itkTBBImageToImageFilter.h
+++ b/include/itkTBBImageToImageFilter.h
@@ -62,6 +62,8 @@ class TBBImageToImageFilter : public ImageToImageFilter< TInputImage, TOutputIma
 #endif // ITK_USE_TBB
 
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(TBBImageToImageFilter);
+
   // Standard class type alias.
   using Self = TBBImageToImageFilter;
   using Superclass = ImageToImageFilter< TInputImage, TOutputImage >;
@@ -169,8 +171,6 @@ protected:
   void PrintSelf(std::ostream &os, Indent indent) const override;
 
 private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(TBBImageToImageFilter);
-
   JobIdType                   m_NumberOfJobs;
   DimensionReductionType      m_NumberOfDimensionToReduce;
 


### PR DESCRIPTION
Move `ITK_DISALLOW_COPY_AND_ASSIGN` calls to public section following
the discussion in
https://discourse.itk.org/t/noncopyable

If legacy (pre-macro) copy and assing methods existed, subsitute them
for the `ITK_DISALLOW_COPY_AND_ASSIGN` macro.