### PR TITLE
COMP: Set the minimum required CMake version to 3.10.2.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(TBBImageToImageFilter)
 file(READ README.md DOCUMENTATION)
 
 if(NOT ITK_SOURCE_DIR)
-    cmake_minimum_required(VERSION 3.9.5 FATAL_ERROR)
+    cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
     find_package(ITK REQUIRED)
     list(APPEND CMAKE_MODULE_PATH ${ITK_CMAKE_DIR})
     include(itk-module-init.cmake)


### PR DESCRIPTION
As agreed in:
https://discourse.itk.org/t/cmake-update/870/

Set the `cmake_minimum_required` to version **3.10.2**.